### PR TITLE
[PR] Only overwrite FROM email on admin notifications

### DIFF
--- a/wsu-smtp.php
+++ b/wsu-smtp.php
@@ -15,6 +15,14 @@ add_action( 'phpmailer_init', 'wsuwp_smtp_email' );
  */
 function wsuwp_smtp_email( $phpmailer ) {
 	$phpmailer->Mailer = 'smtp';
+	$phpmailer->Host = 'smtp.wsu.edu';
+	$phpmailer->Port = 25;
+	$phpmailer->SMTPAuth = false;
+
+	if ( ! is_admin() ) {
+		return;
+	}
+
 	$phpmailer->From = sanitize_email( 'www-data@' . $_SERVER['SERVER_NAME'] );
 
 	if ( is_multisite() ) {
@@ -24,7 +32,4 @@ function wsuwp_smtp_email( $phpmailer ) {
 	}
 
 	$phpmailer->Sender = $phpmailer->From;
-	$phpmailer->Host = 'smtp.wsu.edu';
-	$phpmailer->Port = 25;
-	$phpmailer->SMTPAuth = false;
 }


### PR DESCRIPTION
When notifications are sent from other things, like form confirmations, we should pass along the expected email information.
