### PR TITLE
[PR] Be less assertive with From and FromName

### DIFF
--- a/wsu-smtp.php
+++ b/wsu-smtp.php
@@ -19,16 +19,9 @@ function wsuwp_smtp_email( $phpmailer ) {
 	$phpmailer->Port = 25;
 	$phpmailer->SMTPAuth = false;
 
-	if ( is_multisite() ) {
-		$phpmailer->FromName = esc_html( get_option( 'blogname' ) ) . ' | ' . esc_html( get_current_site()->site_name );
-	} else {
-		$phpmailer->FromName = esc_html( get_option( 'blogname' ) );
-	}
+	// Append some text so that people receiving email know where it was generated.
+	$phpmailer->FromName = $phpmailer->FromName . ' (sent from WSUWP)';
 
-	if ( ! is_admin() ) {
-		return;
-	}
-
-	$phpmailer->From = sanitize_email( 'www-data@' . $_SERVER['SERVER_NAME'] );
+	// This may not be necessary.
 	$phpmailer->Sender = $phpmailer->From;
 }

--- a/wsu-smtp.php
+++ b/wsu-smtp.php
@@ -4,7 +4,7 @@ Plugin Name: WSU SMTP Email
 Plugin URI: http://web.wsu.edu/
 Description: Use SMTP to send email from WordPress
 Author: washingtonstateuniversity, jeremyfelt
-Version: 0.1.2
+Version: 0.1.3
 */
 
 add_action( 'phpmailer_init', 'wsuwp_smtp_email' );


### PR DESCRIPTION
`FromName` is now the original text with a note appended indicating it was sent from the platform.

`From` is now untouched.

Previously, we overwrote both of these—probably to provide a sense of consistency from all of the automated emails. It turns out that this leads to more confusion because various Gravity Forms emails and other notifications all appear to come from the same place.

This may cause a resurgence in the number of emails that we get as fake site admins when we don't change the admin email on a site after handing it over. We'll need to deal with those as they come up and, when needed, look for more interesting ways of filtering emails on a case by case basis.